### PR TITLE
修正 OpenAI 模型的 GPT-4 模型名称，并调整超时设置为 180 秒

### DIFF
--- a/django_text_translator/models.py
+++ b/django_text_translator/models.py
@@ -102,9 +102,7 @@ class OpenAITranslator(TranslatorEngine):
     # https://platform.openai.com/docs/api-reference/chat
     openai_models = [
         "gpt-3.5-turbo",
-        "gpt-3.5-turbo-16k",
-        "gpt-4",
-        "gpt-4-32k",
+        "gpt-4-turbo-preview",
     ]
 
     api_key = EncryptedCharField(_("API Key"), max_length=255)
@@ -126,7 +124,7 @@ class OpenAITranslator(TranslatorEngine):
         return OpenAI(
                     api_key=self.api_key,
                     base_url = self.base_url,
-                    timeout=20.0,
+                    timeout=180.0,
                 )
 
     def validate(self) -> bool:


### PR DESCRIPTION
1. 官方调整了 GPT-4 模型的名称，已经修正为和官方一致，目前两个都是各自版本中效果最好的
2. 受生成速度的影响，OpenAI 接口的返回速度一直偏慢，超时时间过短会导致翻译的时候不停的因为超时而重试以及没有返回值。经过测试，180 秒基本上可以最长满足 4096 token 的翻译需求